### PR TITLE
feat(profile): add ability to update username from profile page

### DIFF
--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -5,12 +5,15 @@ import OrderCard from "../components/OrderCard";
 export default function ProfilePage() {
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [username, setUsername] = useState("");
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     const fetchProfile = async () => {
       try {
         const data = await ProfileService.getProfile();
         setProfile(data.user);
+        setUsername(data.user.name); // Pre-fill username field
       } catch (err) {
         console.error("Error fetching profile", err);
       } finally {
@@ -20,6 +23,22 @@ export default function ProfilePage() {
     fetchProfile();
   }, []);
 
+  const handleUpdateUsername = async () => {
+    if (!username.trim()) return alert("Username cannot be empty");
+
+    setSaving(true);
+    try {
+      const updatedUser = await ProfileService.updateProfile({ name: username });
+      setProfile((prev) => ({ ...prev, name: updatedUser.name }));
+      alert("Username updated successfully!");
+    } catch (err) {
+      console.error("Error updating username", err);
+      alert("Failed to update username");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (loading) return <p className="text-center mt-8">Loading profile...</p>;
 
   return (
@@ -27,10 +46,31 @@ export default function ProfilePage() {
       <h2 className="text-2xl font-bold mb-4">My Profile</h2>
 
       {/* Profile Info */}
-      <div className="mb-6">
+      <div className="mb-6 space-y-2">
         <p><strong>Email:</strong> {profile.email}</p>
         <p><strong>Roles:</strong> {profile.roles.join(", ")}</p>
         <p><strong>Joined:</strong> {new Date(profile.created_at).toLocaleDateString()}</p>
+      </div>
+
+      {/* Update Username */}
+      <div className="mb-8">
+        <h3 className="text-lg font-semibold mb-2">Update Username</h3>
+        <div className="flex items-center space-x-4">
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="border rounded p-2 w-64"
+            placeholder="Enter new username"
+          />
+          <button
+            onClick={handleUpdateUsername}
+            disabled={saving}
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Update"}
+          </button>
+        </div>
       </div>
 
       {/* Orders List */}


### PR DESCRIPTION
# **🚀Refactor: Add Username Update Feature to Profile Page**

## **Summary**
This PR adds frontend functionality to allow users to update their **username** directly from the profile page.  
The profile now includes an editable username field and an **Update** button, which sends a request to the backend to update the user's name.

---

## **Why This Change**
- Improves **personalization** by allowing users to customize their display name.
- Enhances the overall **user experience** with an easy-to-use update flow.
- Keeps sensitive information like email and roles protected, as only the `name` field is editable from the UI.

---

## **Implementation Details**
- Added a **username input field** to the profile page.
- Added an **Update** button to submit changes to the backend.
- On successful update:
  - The updated username is immediately displayed in the profile page.
  - Smooth UX with loading and error handling.

---

## **Testing Steps**
1. Navigate to `/profile` in the frontend.
2. Update the **username field** with a new value.
3. Click **Update**.
4. Verify:
   - A `PUT /api/v1/profile` request is sent with the updated name.
   - The updated name appears instantly on the profile page.
   - No other fields like email or roles are changed.

---

## **Next Steps**
- Add form validation to prevent empty or invalid usernames.
- Show success and error messages for better feedback to users.
